### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/release.branch.yml
+++ b/.github/workflows/release.branch.yml
@@ -11,7 +11,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/release-')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.pr.merge.yml
+++ b/.github/workflows/release.pr.merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: release

--- a/.github/workflows/update-beta-packages.yml
+++ b/.github/workflows/update-beta-packages.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.
Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0